### PR TITLE
feat: Import and Export of settings

### DIFF
--- a/src/routes/(app)/settings/+page.svelte
+++ b/src/routes/(app)/settings/+page.svelte
@@ -9,6 +9,9 @@
 	import SettingsButton from '$lib/components/settings/SettingsButton.svelte';
 	import Icon from '$lib/components/common/Icon.svelte';
 	import { faInfoCircle } from '@fortawesome/free-solid-svg-icons/faInfoCircle';
+	import { faFileImport } from '@fortawesome/free-solid-svg-icons/faFileImport';
+	import { faFileExport } from '@fortawesome/free-solid-svg-icons/faFileExport';
+	import { onMount } from 'svelte';
 
 	function clrCache() {
 		clearCache();

--- a/src/routes/(app)/settings/+page.svelte
+++ b/src/routes/(app)/settings/+page.svelte
@@ -27,11 +27,15 @@
 		const reader = new FileReader();
 		reader.onload = () => {
 			try {
-				const settings = JSON.parse(reader.result as string);
-				settingsStore.set(settings);
-				toast.success('Einstellungen importiert', {
+				const parsed = JSON.parse(reader.result as string);
+				localStorage.clear();
+				for (const key in parsed) {
+					localStorage.setItem(key, parsed[key]);
+				}
+				toast.success('Einstellungen importiert, starte neu...', {
 					duration: 2000
 				});
+				setTimeout(() => location.reload(), 1000);
 			} catch (e) {
 				toast.error('Fehler beim Importieren der Einstellungen', {
 					duration: 2000
@@ -44,10 +48,10 @@
 	onMount(() => {
 		// Get the file contents
 		// let txtFile = `vertretungsapp-settings_${new Date().toISOString().replace(/:/g, '-')}.json`;
-		let str = JSON.stringify($settingsStore);
+		const str = JSON.stringify({ ...localStorage });
 
 		// Save the file contents as a DataURI
-		let dataUri = 'data:application/json;charset=utf-8,' + encodeURIComponent(str);
+		const dataUri = 'data:application/json;charset=utf-8,' + encodeURIComponent(str);
 
 		// Write it as the href for the link
 		const link = document.getElementById('export_settings_json') as HTMLAnchorElement;

--- a/src/routes/(app)/settings/+page.svelte
+++ b/src/routes/(app)/settings/+page.svelte
@@ -115,7 +115,7 @@
 			<Icon icon={faFileImport} scale={1.1} />
 			Importieren
 		</label>
-		<input id="import_settings_json" type="file" class="hidden" on:input={importSettings} />
+		<input id="import_settings_json" type="file" class="hidden" accept="application/json" on:input={importSettings} />
 	</SettingsSection>
 
 	<SettingsSection>

--- a/src/routes/(app)/settings/+page.svelte
+++ b/src/routes/(app)/settings/+page.svelte
@@ -115,7 +115,13 @@
 			<Icon icon={faFileImport} scale={1.1} />
 			Importieren
 		</label>
-		<input id="import_settings_json" type="file" class="hidden" accept="application/json" on:input={importSettings} />
+		<input
+			id="import_settings_json"
+			type="file"
+			class="hidden"
+			accept="application/json"
+			on:input={importSettings}
+		/>
 	</SettingsSection>
 
 	<SettingsSection>

--- a/src/routes/(app)/settings/+page.svelte
+++ b/src/routes/(app)/settings/+page.svelte
@@ -16,6 +16,43 @@
 			duration: 2000
 		});
 	}
+
+	function importSettings(event: Event & { currentTarget: EventTarget & HTMLInputElement }) {
+		const file = event.currentTarget.files?.[0];
+		if (!file) return;
+
+		const reader = new FileReader();
+		reader.onload = () => {
+			try {
+				const settings = JSON.parse(reader.result as string);
+				settingsStore.set(settings);
+				toast.success('Einstellungen importiert', {
+					duration: 2000
+				});
+			} catch (e) {
+				toast.error('Fehler beim Importieren der Einstellungen', {
+					duration: 2000
+				});
+			}
+		};
+		reader.readAsText(file);
+	}
+
+	onMount(() => {
+		// Get the file contents
+		// let txtFile = `vertretungsapp-settings_${new Date().toISOString().replace(/:/g, '-')}.json`;
+		let str = JSON.stringify($settingsStore);
+
+		// Save the file contents as a DataURI
+		let dataUri = 'data:application/json;charset=utf-8,' + encodeURIComponent(str);
+
+		// Write it as the href for the link
+		const link = document.getElementById('export_settings_json') as HTMLAnchorElement;
+		if (link) {
+			link.href = dataUri;
+			link.download = `vertretungsapp-settings_${new Date().toISOString().replace(/:/g, '-')}.json`;
+		}
+	});
 </script>
 
 <div class="flex w-full justify-end"></div>
@@ -54,6 +91,28 @@
 			Anonyme Fehlerberichte zur Analyse und Verbesserung der App an Sentry senden (Neustart
 			erforderlich)
 		</SettingsCheckbox>
+	</SettingsSection>
+
+	<SettingsSection>
+		<svelte:fragment slot="title">Im-/Export der Einstellungen</svelte:fragment>
+
+		<a
+			class="bg-clickable col-span-5 flex items-center justify-center gap-2 rounded-lg p-2"
+			href="/settings"
+			id="export_settings_json"
+		>
+			<Icon icon={faFileExport} scale={1.1} />
+			Exportieren
+		</a>
+
+		<label
+			for="import_settings_json"
+			class="bg-clickable col-span-5 flex items-center justify-center gap-2 rounded-lg p-2"
+		>
+			<Icon icon={faFileImport} scale={1.1} />
+			Importieren
+		</label>
+		<input id="import_settings_json" type="file" class="hidden" on:input={importSettings} />
 	</SettingsSection>
 
 	<SettingsSection>


### PR DESCRIPTION
It is now possible to import and export settings in json format for more power users.
The export UX is kinda bad, but that is mostly due to iOS. Should be enough I think for this usecase.